### PR TITLE
Use relative files and forward slashes on Windows

### DIFF
--- a/unsilence/lib/render_media/MediaRenderer.py
+++ b/unsilence/lib/render_media/MediaRenderer.py
@@ -145,18 +145,18 @@ class MediaRenderer:
         total_files = len(file_list)
 
         with open(str(concat_file), "w+") as file:
-            lines = [f"file {interval_file}\n" for interval_file in file_list]
+            lines = [f"file {interval_file.name}\n" for interval_file in file_list]
             file.writelines(lines)
 
         command = [
             "ffmpeg",
             "-f", "concat",
             "-safe", "0",
-            "-i", f"{concat_file}",
+            "-i", f"{concat_file.as_posix()}",
             "-c", "copy",
             "-y",
             "-loglevel", "verbose",
-            f"{output_file}"
+            f"{output_file.as_posix()}"
         ]
 
         console_output = subprocess.Popen(


### PR DESCRIPTION
Using absolute filepaths in ffmpeg concat lists is considered unsafe and will not work in some cases.
I changed them to relative filenames instead and replaced backslashes to forward slashes for Windows compatibility.
Fixes #4 in some cases.
Tested on Windows 10 1909 x64.