### PR TITLE
ffmpeg_version: Handle "n" prefix

### DIFF
--- a/unsilence/lib/tools/ffmpeg_version.py
+++ b/unsilence/lib/tools/ffmpeg_version.py
@@ -12,7 +12,7 @@ def get_ffmpeg_version():
     except FileNotFoundError:
         return None
 
-    match = re.search("ffmpeg version (\d+\.\d+\.\d+)", str(console_output))
+    match = re.search("ffmpeg version \D?(\d+\.\d+\.\d+)", str(console_output))
     groups = match.groups()
 
     version = groups[0].split(".")


### PR DESCRIPTION
In my distro, I get the following output from `ffmpeg -version`:
```
ffmpeg version n4.2.3 Copyright (c) 2000-2020 the FFmpeg developers
```

Also see: https://github.com/FFmpeg/FFmpeg/releases

This commit updates the regex to match an optional letter before version number.