### PR TITLE
Added silence_level_analysis (sla) for easier deciding of silence level

### DIFF
--- a/unsilence/command_line/ParseArguments.py
+++ b/unsilence/command_line/ParseArguments.py
@@ -88,5 +88,7 @@ def parse_arguments():
 
     parser.add_argument("-d", "--debug", action="store_true",
                         help="Enable debug output (StackTrace)")
+    parser.add_argument("-sla", "--silence-level-analysis", action="store_true",
+                        help="Helps to decide silence level, might take some time.")
 
     return parser.parse_args()

--- a/unsilence/command_line/PrettyTimeEstimate.py
+++ b/unsilence/command_line/PrettyTimeEstimate.py
@@ -55,3 +55,33 @@ def pretty_time_estimate(time_data: dict):
     )
 
     return table
+
+def pretty_time_estimate_sla(time_data: dict):
+    """
+    Printing the silent level analysis
+    Generates a rich.table.Table object from the time_data dict (from lib.Intervals.TimeCalculations.calculate_time)
+    :param time_data: time_data nested dict with silence levels
+    :return: rich.table.Table object
+    """
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Silence Levels")
+    table.add_column("Detected Silence")
+    table.add_column("Combined_Before")
+    table.add_column("Combined_After")
+
+    for key in time_data.keys():
+        reorderer_time_data = {"all": {}, "audible": {}, "silent": {}}
+        for column, row_with_values in time_data[key].items():
+            for row, values in row_with_values.items():
+                time_delta = format_timedelta(round(values[0]))
+                reorderer_time_data[row][column] = f"{time_delta} ([cyan]{round(values[1] * 100, 1)}%[/cyan])"
+        table.add_row(
+        key.split('_')[-1],
+        reorderer_time_data["silent"]["before"],
+        reorderer_time_data["all"]["before"],
+        reorderer_time_data["all"]["after"]
+        )
+    return table
+
+
+    


### PR DESCRIPTION
It is a bit time consuming to test silence levels for videos by repeatedly entering different silence level commands , and some videos I used unsilence on had 0 difference using the default -35 silence level, so I thought of creating a table with multiple silence levels that would make good reference for user to decide what the silence level should be. Can be easily expanded by just changing the list values.

Here’s a short video demo of how it works on my Win10:
https://www.youtube.com/watch?v=raWyQhvf4WI&feature=youtu.be
