### PR TITLE
Added option to check for bad intervals

### DIFF
--- a/unsilence/command_line/EntryPoint.py
+++ b/unsilence/command_line/EntryPoint.py
@@ -55,7 +55,7 @@ def run():
 
     argument_list_for_renderer = [
         "audio_only", "audible_speed", "silent_speed", "audible_volume", "silent_volume",
-        "drop_corrupted_intervals", "threads", "skip_check_intervals"
+        "drop_corrupted_intervals", "threads", "check_intervals"
     ]
 
     argument_dict_for_renderer = {

--- a/unsilence/command_line/EntryPoint.py
+++ b/unsilence/command_line/EntryPoint.py
@@ -55,7 +55,7 @@ def run():
 
     argument_list_for_renderer = [
         "audio_only", "audible_speed", "silent_speed", "audible_volume", "silent_volume",
-        "drop_corrupted_intervals", "threads", "check_intervals"
+        "drop_corrupted_intervals", "threads", "check_intervals", "minimum_interval_duration"
     ]
 
     argument_dict_for_renderer = {

--- a/unsilence/command_line/EntryPoint.py
+++ b/unsilence/command_line/EntryPoint.py
@@ -55,7 +55,7 @@ def run():
 
     argument_list_for_renderer = [
         "audio_only", "audible_speed", "silent_speed", "audible_volume", "silent_volume",
-        "drop_corrupted_intervals", "threads"
+        "drop_corrupted_intervals", "threads", "check_intervals"
     ]
 
     argument_dict_for_renderer = {

--- a/unsilence/command_line/EntryPoint.py
+++ b/unsilence/command_line/EntryPoint.py
@@ -55,7 +55,7 @@ def run():
 
     argument_list_for_renderer = [
         "audio_only", "audible_speed", "silent_speed", "audible_volume", "silent_volume",
-        "drop_corrupted_intervals", "threads", "check_intervals"
+        "drop_corrupted_intervals", "threads", "skip_check_intervals"
     ]
 
     argument_dict_for_renderer = {

--- a/unsilence/command_line/ParseArguments.py
+++ b/unsilence/command_line/ParseArguments.py
@@ -70,6 +70,8 @@ def parse_arguments():
                         help="The volume at which silent parts should be played back at")
     parser.add_argument("-dci", "--drop-corrupted-intervals", action="store_true",
                         help="Whether corrupted video intervals should be discarded or tried to recover")
+    parser.add_argument("-ci", "--check-intervals", action="store_true",
+                        help="Check for bad intervals and skip them in the final concatenation")
 
     parser.add_argument("-t", "--threads", type=number_bigger_than_zero, default=2,
                         help="Number of threads to be used while rendering")

--- a/unsilence/command_line/ParseArguments.py
+++ b/unsilence/command_line/ParseArguments.py
@@ -70,8 +70,8 @@ def parse_arguments():
                         help="The volume at which silent parts should be played back at")
     parser.add_argument("-dci", "--drop-corrupted-intervals", action="store_true",
                         help="Whether corrupted video intervals should be discarded or tried to recover")
-    parser.add_argument("-sci", "--skip-check-intervals", action="store_true",
-                        help="Don't check for intervals that are too short and can't be concatenated")
+    parser.add_argument("-sci", "--check-intervals", action="store_true",
+                        help="Check for and skip intervals that are too short to be concatenated")
 
     parser.add_argument("-t", "--threads", type=number_bigger_than_zero, default=2,
                         help="Number of threads to be used while rendering")

--- a/unsilence/command_line/ParseArguments.py
+++ b/unsilence/command_line/ParseArguments.py
@@ -70,8 +70,11 @@ def parse_arguments():
                         help="The volume at which silent parts should be played back at")
     parser.add_argument("-dci", "--drop-corrupted-intervals", action="store_true",
                         help="Whether corrupted video intervals should be discarded or tried to recover")
-    parser.add_argument("-sci", "--check-intervals", action="store_true",
+    parser.add_argument("-ci", "--check-intervals", action="store_true",
                         help="Check for and skip intervals that are too short to be concatenated")
+    parser.add_argument("-mid", "--minimum-interval-duration", type=float, default=0.25,
+                        help="Minimum duration of an interval after speedup to ensure correct concatenation")
+
 
     parser.add_argument("-t", "--threads", type=number_bigger_than_zero, default=2,
                         help="Number of threads to be used while rendering")

--- a/unsilence/command_line/ParseArguments.py
+++ b/unsilence/command_line/ParseArguments.py
@@ -70,8 +70,8 @@ def parse_arguments():
                         help="The volume at which silent parts should be played back at")
     parser.add_argument("-dci", "--drop-corrupted-intervals", action="store_true",
                         help="Whether corrupted video intervals should be discarded or tried to recover")
-    parser.add_argument("-ci", "--check-intervals", action="store_true",
-                        help="Check for bad intervals and skip them in the final concatenation")
+    parser.add_argument("-sci", "--skip-check-intervals", action="store_true",
+                        help="Don't check for intervals that are too short and can't be concatenated")
 
     parser.add_argument("-t", "--threads", type=number_bigger_than_zero, default=2,
                         help="Number of threads to be used while rendering")

--- a/unsilence/command_line/ParseArguments.py
+++ b/unsilence/command_line/ParseArguments.py
@@ -71,7 +71,7 @@ def parse_arguments():
     parser.add_argument("-dci", "--drop-corrupted-intervals", action="store_true",
                         help="Whether corrupted video intervals should be discarded or tried to recover")
     parser.add_argument("-ci", "--check-intervals", action="store_true",
-                        help="Check for and skip intervals that are too short to be concatenated")
+                        help="Actively checks for invalid intervals and drops them (Takes longer)")
     parser.add_argument("-mid", "--minimum-interval-duration", type=float, default=0.25,
                         help="Minimum duration of an interval after speedup to ensure correct concatenation")
 

--- a/unsilence/lib/render_media/MediaRenderer.py
+++ b/unsilence/lib/render_media/MediaRenderer.py
@@ -59,7 +59,8 @@ class MediaRenderer:
             audible_volume=kwargs.get("audible_volume", 1),
             silent_volume=kwargs.get("silent_volume", 0.5),
             drop_corrupted_intervals=kwargs.get("drop_corrupted_intervals", False),
-            check_intervals=kwargs.get("check_intervals", False)
+            check_intervals=kwargs.get("check_intervals", False),
+            minimum_interval_duration=kwargs.get("minimum_interval_duration", 0.25)
         )
 
         intervals = intervals.remove_short_intervals_from_start(

--- a/unsilence/lib/render_media/MediaRenderer.py
+++ b/unsilence/lib/render_media/MediaRenderer.py
@@ -59,7 +59,7 @@ class MediaRenderer:
             audible_volume=kwargs.get("audible_volume", 1),
             silent_volume=kwargs.get("silent_volume", 0.5),
             drop_corrupted_intervals=kwargs.get("drop_corrupted_intervals", False),
-            skip_check_intervals=kwargs.get("skip_check_intervals", False)
+            check_intervals=kwargs.get("check_intervals", False)
         )
 
         intervals = intervals.remove_short_intervals_from_start(

--- a/unsilence/lib/render_media/MediaRenderer.py
+++ b/unsilence/lib/render_media/MediaRenderer.py
@@ -58,7 +58,8 @@ class MediaRenderer:
             silent_speed=kwargs.get("silent_speed", 6),
             audible_volume=kwargs.get("audible_volume", 1),
             silent_volume=kwargs.get("silent_volume", 0.5),
-            drop_corrupted_intervals=kwargs.get("drop_corrupted_intervals", False)
+            drop_corrupted_intervals=kwargs.get("drop_corrupted_intervals", False),
+            check_intervals=kwargs.get("check_intervals", False)
         )
 
         intervals = intervals.remove_short_intervals_from_start(

--- a/unsilence/lib/render_media/MediaRenderer.py
+++ b/unsilence/lib/render_media/MediaRenderer.py
@@ -59,7 +59,7 @@ class MediaRenderer:
             audible_volume=kwargs.get("audible_volume", 1),
             silent_volume=kwargs.get("silent_volume", 0.5),
             drop_corrupted_intervals=kwargs.get("drop_corrupted_intervals", False),
-            check_intervals=kwargs.get("check_intervals", False)
+            skip_check_intervals=kwargs.get("skip_check_intervals", False)
         )
 
         intervals = intervals.remove_short_intervals_from_start(

--- a/unsilence/lib/render_media/RenderIntervalThread.py
+++ b/unsilence/lib/render_media/RenderIntervalThread.py
@@ -52,7 +52,7 @@ class RenderIntervalThread(threading.Thread):
                     drop_corrupted_intervals=self.__render_options.drop_corrupted_intervals
                 )
 
-                if completed and self.__render_options.check_intervals:
+                if completed and not self.__render_options.skip_check_intervals:
                     probe_output = subprocess.run(
                         [
                             "ffprobe",

--- a/unsilence/lib/render_media/RenderIntervalThread.py
+++ b/unsilence/lib/render_media/RenderIntervalThread.py
@@ -52,6 +52,18 @@ class RenderIntervalThread(threading.Thread):
                     drop_corrupted_intervals=self.__render_options.drop_corrupted_intervals
                 )
 
+                if completed and self.__render_options.check_intervals:
+                    probe_output = subprocess.run(
+                        [
+                            "ffprobe",
+                            "-loglevel", "quiet",
+                            f"{task.interval_output_file}"
+                        ],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.STDOUT
+                    )
+                    completed = probe_output.returncode == 0
+
                 if self.__on_task_completed is not None:
                     self.__on_task_completed(task, not completed)
             else:


### PR DESCRIPTION
This addresses the isssue #108 (See [the investigation comment there](https://github.com/lagmoellertim/unsilence/issues/108#issuecomment-1292115418) for more details).

Unfortunately, there doesn't seem to be a way to tell the concat script of ffmpeg directly to ignore files it can't handle. And the ffmpeg command that produces the bad interval files in the first place doesn't seem to be aware either that it is doing so. 

So I added an additional command line option (`--check-intervals`) that, if provided, causes the `RenderIntervalThread` to run `ffprobe` on the rendered file for each interval to ensure that it will be recognized by ffmpeg later in the concatenation step.

I made this optional, since running `ffprobe` for every interval's file adds quite a bit to the total runtime of the program (For my test file, it went from 0:02:06 to 0:02:36). Though if it is considered acceptable in face of the fact that it prevents the output file from silently being truncated, it could also just be made the default behavior. I would argue for that, but to be conservative, I have opted to implement it as optional for now.