### PR TITLE
adjusted default estimate_time() values

### DIFF
--- a/unsilence/Unsilence.py
+++ b/unsilence/Unsilence.py
@@ -69,7 +69,7 @@ class Unsilence:
         """
         return self.__intervals
 
-    def estimate_time(self, audible_speed: float = 6, silent_speed: float = 1):
+    def estimate_time(self, audible_speed: float = 1, silent_speed: float = 6):
         """
         Estimates the time (savings) when the current options are applied to the intervals
 


### PR DESCRIPTION
The estimate_time() function used different default values than everything else.
I updated them to now use the default values (audible_speed = 1, silent_speed = 6).